### PR TITLE
Remove emoji CDN hostname from DNS prefetching hints

### DIFF
--- a/disable-emojis.php
+++ b/disable-emojis.php
@@ -40,6 +40,7 @@ function disable_emojis() {
 	remove_filter( 'comment_text_rss', 'wp_staticize_emoji' );	
 	remove_filter( 'wp_mail', 'wp_staticize_emoji_for_email' );
 	add_filter( 'tiny_mce_plugins', 'disable_emojis_tinymce' );
+	add_filter( 'wp_resource_hints', 'disable_emojis_remove_dns_prefetch', 10, 2 );
 }
 add_action( 'init', 'disable_emojis' );
 
@@ -57,3 +58,20 @@ function disable_emojis_tinymce( $plugins ) {
 	}
 }
 
+/**
+ * Remove emoji CDN hostname from DNS prefetching hints.
+ *
+ * @param  array  $urls          URLs to print for resource hints.
+ * @param  string $relation_type The relation type the URLs are printed for.
+ * @return array                 Difference betwen the two arrays.
+ */
+function disable_emojis_remove_dns_prefetch( $urls, $relation_type ) {
+	if ( 'dns-prefetch' == $relation_type ) {
+		/** This filter is documented in wp-includes/formatting.php */
+		$emoji_svg_url = apply_filters( 'emoji_svg_url', 'https://s.w.org/images/core/emoji/2/svg/' );
+
+		$urls = array_diff( $urls, array( $emoji_svg_url ) );
+	}
+
+	return $urls;
+}


### PR DESCRIPTION
WordPress 4.6 introduced new `wp_resource_hints()` function that places DNS prefetching link for emoji CDN in a head of every single page. Since we disable emoji, we don't need this so I propose that we remove it as well.
