### PR TITLE
removed redundant code

### DIFF
--- a/disable-emojis.php
+++ b/disable-emojis.php
@@ -53,9 +53,9 @@ add_action( 'init', 'disable_emojis' );
 function disable_emojis_tinymce( $plugins ) {
 	if ( is_array( $plugins ) ) {
 		return array_diff( $plugins, array( 'wpemoji' ) );
-	} else {
-		return array();
 	}
+
+	return array();
 }
 
 /**


### PR DESCRIPTION
I haven't checked but I feel like you could return an empty variable and WP wouldn't complain, in which case you could assign the value returned from array_diff() to $plugins and return just that.